### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -8,6 +8,10 @@ on:
       - api/**
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/djoamersfoort/media/security/code-scanning/2](https://github.com/djoamersfoort/media/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/api.yaml` at the workflow root (recommended here since there is only one job), using the minimal required permissions for current behavior:

- `contents: read` (needed for checkout/read repository content)
- `packages: write` (needed to push container image to GHCR and delete old package versions)

This preserves existing functionality while limiting token scope.  
Edit location: insert between the `on:` block and `jobs:` block in `.github/workflows/api.yaml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
