### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -8,6 +8,10 @@ on:
       - client/**
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/djoamersfoort/media/security/code-scanning/1](https://github.com/djoamersfoort/media/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/client.yaml` so the workflow limits `GITHUB_TOKEN` scopes to only what this job needs.

Best fix (without changing behavior): define workflow-level permissions directly under `on:`/before `jobs:`:

- `contents: read` (needed by `actions/checkout`)
- `packages: write` (needed to push container image to GHCR and delete old package versions)

This aligns with CodeQL’s suggested minimal starting point and preserves current functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
